### PR TITLE
Upgrade cartopy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,28 +14,14 @@ RUN apt-get update \
 &&  apt clean \
 &&  rm -rf /var/lib/apt/lists/*
 
+COPY environment.yml /tmp/environment.yml
+
 RUN conda install setuptools \
 &&  conda update conda \
-&&  conda config --add channels conda-forge  \
-&&  conda install -y \
-    cartopy=0.20.0 \
-    coverage=5.2.1 \
-    coveralls=2.1.2 \
-    gdal=3.1.2 \
-    ipdb=0.13.3 \
-    ipython=7.17.0 \
-    matplotlib=3.3.1 \
-    mock=4.0.2 \
-    netcdf4=1.5.4 \
-    nose=1.3.7 \
-    numpy=1.19.1 \
-    pillow=7.2.0 \
-    python-dateutil=2.8.1 \
-    scipy=1.5.2 \
-    urllib3=1.25.10 \
+&&  conda env update -n base --file /tmp/environment.yml \
+&&  rm /tmp/environment.yml \
 &&  conda clean -a -y \
 &&  rm /opt/conda/pkgs/* -rf \
-&&  pip install pythesint==1.5.1 \
 &&  python -c 'import pythesint; pythesint.update_all_vocabularies()' \
 &&  wget -nc -nv -P /usr/share/MOD44W https://github.com/nansencenter/mod44w/raw/master/MOD44W.tgz \
 &&  tar -xzf /usr/share/MOD44W/MOD44W.tgz -C /usr/share/MOD44W/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN conda install setuptools \
 &&  conda update conda \
 &&  conda config --add channels conda-forge  \
 &&  conda install -y \
-    cartopy=0.18.0 \
+    cartopy=0.20.0 \
     coverage=5.2.1 \
     coveralls=2.1.2 \
     gdal=3.1.2 \

--- a/environment.yml
+++ b/environment.yml
@@ -4,22 +4,23 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - setuptools
-  - cartopy=0.20.0
-  - coverage=5.2.1
-  - coveralls=2.1.2
-  - gdal=3.1.2
-  - ipdb=0.13.3
-  - ipython=7.17.0
-  - matplotlib=3.3.1
-  - mock=4.0.2
-  - netcdf4=1.5.4
-  - nose=1.3.7
-  - numpy=1.19.1
-  - pillow=7.2.0
-  - pip
-  - python-dateutil=2.8.1
-  - scipy=1.5.2
-  - urllib3=1.25.10
+  - setuptools=60.1
+  - cartopy=0.20.1
+  - coverage=6.2
+  - coveralls=3.3
+  - gdal=3.4
+  - ipdb=0.13
+  - ipython=7.30
+  - matplotlib=3.5
+  - mock=4.0
+  - netcdf4=1.5
+  - nose=1.3
+  - numpy=1.21.5
+  - pillow=8.4
+  - pip=21
+  - python-dateutil=2.8
+  - PyYAML<6.0
+  - scipy=1.7
+  - urllib3=1.26
   - pip:
-      - pythesint==1.5.1
+      - pythesint==1.6.1

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - mock=4.0
   - netcdf4=1.5
   - nose=1.3
-  - numpy=1.21.5
+  - numpy=1.21
   - pillow=8.4
   - pip=21
   - python-dateutil=2.8

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - setuptools
-  - cartopy=0.18.0
+  - cartopy=0.20.0
   - coverage=5.2.1
   - coveralls=2.1.2
   - gdal=3.1.2


### PR DESCRIPTION
Resolves #18 

Needs nansencenter/nansat#513 to be merged first.

Also the Dockerfile for the standard image now uses the environment.yml file, so that the packages versions are specified in only one place.

FYI @korvinos 