### PR TITLE
Update pythesint to version 1.6.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,4 @@ dependencies:
   - scipy=1.7
   - urllib3=1.26
   - pip:
-      - pythesint==1.6.1
+      - pythesint==1.6.2


### PR DESCRIPTION
Version 1.6.2 of Pythesint includes a fix for the change of the data structure of platforms in the GCMD web service.