### PR TITLE
Update pythesint to 1.6.6

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -25,7 +25,7 @@ jobs:
           echo "::set-output name=VERSION::${TAG}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-buildx-standard-
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 
 COPY environment.yml /tmp/environment.yml
 
-RUN conda install setuptools \
+RUN conda install python=3.7 setuptools \
 &&  conda update conda \
 &&  conda env update -n base --file /tmp/environment.yml \
 &&  rm /tmp/environment.yml \

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,4 @@ dependencies:
   - scipy=1.7
   - urllib3=1.26
   - pip:
-      - pythesint==1.6.3
+      - pythesint==1.6.6


### PR DESCRIPTION
Update pythesint version to 1.6.6

A few updates had to be made to the Github actions and the standard Dockerfile for the build to work.

FYI @akorosov 