### PR TITLE
Update pyyaml version to 6.0.1

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       latest: ${{ matrix.python_version == '3.11' && 'true' || '' }}
     strategy:
+      fail-fast: false
       matrix:
         python_version:
           - '3.7'

--- a/environment-3.10.yml
+++ b/environment-3.10.yml
@@ -22,7 +22,7 @@ dependencies:
   - pillow=10.1.0
   - pip=23.3
   - pyshp=2.3.1
-  - PyYAML=5.4.1
+  - PyYAML=6.0.1
   - scipy=1.11.3
   - setuptools=68.0.0
   - urllib3=2.0.3

--- a/environment-3.11.yml
+++ b/environment-3.11.yml
@@ -22,7 +22,7 @@ dependencies:
   - pillow=10.1.0
   - pip=23.3
   - pyshp=2.3.1
-  - PyYAML=5.4.1
+  - PyYAML=6.0.1
   - scipy=1.11.3
   - setuptools=68.0.0
   - urllib3=2.0.3

--- a/environment-3.8.yml
+++ b/environment-3.8.yml
@@ -20,7 +20,7 @@ dependencies:
   - numpy-base=1.24.3
   - pillow=10.0.1
   - pip=23.3
-  - PyYAML=5.4.1
+  - PyYAML=6.0.1
   - scipy=1.10.1
   - setuptools=68.0.0
   - shapely=1.8.4

--- a/environment-3.9.yml
+++ b/environment-3.9.yml
@@ -20,7 +20,7 @@ dependencies:
   - numpy-base=1.26.0
   - pillow=10.0.1
   - pip=23.3
-  - PyYAML=5.4.1
+  - PyYAML=6.0.1
   - scipy=1.11.3
   - setuptools=68.0.0
   - shapely=1.8.4


### PR DESCRIPTION
Starting with Python 3.8, use pyyaml 6.0.1